### PR TITLE
Quick Fix: Prevent Page from Breaking when Dates are Cleared 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -132,10 +132,11 @@ function App() {
       <AppLayout>
           <Dashboard
            
-            onDateRangeChange={dateRange =>
-              setDateRange(dateRange)
-            }
-            
+            onDateRangeChange={dateRange => {
+                if (dateRange[0] !== "" && dateRange[1] !== "") {
+                  setDateRange(dateRange);
+                };
+            }}
           >
             <DashboardItem size={24} title="Most popular tech keywords in HN job ads">
                 <BarChartRace 


### PR DESCRIPTION
## Description 

This PR fixes a small a bug on date range picker which breaks the UI. When the cross is clicked, it sends empty date strings which breaks the component. 

<img width="1158" alt="image" src="https://user-images.githubusercontent.com/47540683/127933320-f67c89bd-51e5-41b8-963a-441895099226.png">

## Better Solution
A better solution would be to get min and max date from data and limit date picker to that range only.
